### PR TITLE
 Open a GitHub URL in a new tab

### DIFF
--- a/site/src/lib/components/card.svelte
+++ b/site/src/lib/components/card.svelte
@@ -69,7 +69,7 @@
 	});
 </script>
 
-<a href={`https://github.com/${username}`} class="card" bind:this={cardRef}>
+<a href={`https://github.com/${username}`} class="card" bind:this={cardRef} target="_blank" rel="noopener noreferrer">
 	<div class="image-container">
 		<img
 			src={screenshot}


### PR DESCRIPTION
# Type of change

- [ ] Added, Removed or Updated GitHub Profile README
- [ ] Bug fix
- [ ] New feature
- [x] Improvement

## Describe change does this PR introduce?

Added target="_blank" rel="noopener noreferrer" to the GitHub card links to ensure that when users click on the links, the GitHub pages open in a new tab for a better user experience.

<!--
If you've added, removed, or updated your GitHub Profile README, please take a moment to describe the changes.
--->

<!--
Similarly, if you've made any changes to your site, please provide a clear and precise description of the changes, including any relevant motivation and context. Additionally, please list any dependencies that are required for this change to be implemented.
--->

## Checklist

- [x] The commit message follows our guidelines.
- [x] The code has been self reviewed and tested.
- [ ] Added or Updated Github Profile README.
  - [ ] The Github Profile README is impressive and visually appealing.
  - [ ] Added it below the heading of the category in alphabetical order.

## Additional context

<!--
If you've added, removed, or updated your GitHub Profile README:

- Link of the Github Profile
- Screenshots of the Github Profile README
- Any other relevant information
--->

<!--
Similarly, if you've made any changes to the site:

- Screenshots or mockups, if applicable
- Environment details (e.g. browser, operating system, version of the project)
- Any other relevant information
--->
